### PR TITLE
Fix build on Plan 9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/libp2p/go-reuseport-transport
 
 require (
 	github.com/ipfs/go-log v0.0.1
-	github.com/libp2p/go-netroute v0.1.2
-	github.com/libp2p/go-reuseport v0.0.1
+	github.com/libp2p/go-netroute v0.1.3
+	github.com/libp2p/go-reuseport v0.0.2
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multiaddr-net v0.1.3
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,13 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/libp2p/go-netroute v0.1.2 h1:UHhB35chwgvcRI392znJA3RCBtZ3MpE3ahNCN5MR4Xg=
 github.com/libp2p/go-netroute v0.1.2/go.mod h1:jZLDV+1PE8y5XxBySEBgbuVAXbhtuHSdmLPL2n9MKbk=
+github.com/libp2p/go-netroute v0.1.3 h1:1ngWRx61us/EpaKkdqkMjKk/ufr/JlIFYQAxV2XX8Ig=
+github.com/libp2p/go-netroute v0.1.3/go.mod h1:jZLDV+1PE8y5XxBySEBgbuVAXbhtuHSdmLPL2n9MKbk=
 github.com/libp2p/go-reuseport v0.0.1 h1:7PhkfH73VXfPJYKQ6JwS5I/eVcoyYi9IMNGc6FWpFLw=
 github.com/libp2p/go-reuseport v0.0.1/go.mod h1:jn6RmB1ufnQwl0Q1f+YxAj8isJgDCQzaaxIFYDhcYEA=
+github.com/libp2p/go-reuseport v0.0.2 h1:XSG94b1FJfGA01BUrT82imejHQyTxO4jEWqheyCXYvU=
+github.com/libp2p/go-reuseport v0.0.2/go.mod h1:SPD+5RwGC7rcnzngoYC86GjPzjSywuQyMVAheVBD9nQ=
+github.com/libp2p/go-sockaddr v0.0.2 h1:tCuXfpA9rq7llM/v834RKc/Xvovy/AqM9kHvTV/jY/Q=
 github.com/libp2p/go-sockaddr v0.0.2/go.mod h1:syPvOmNs24S3dFVGJA1/mrqdeijPxLV2Le3BRLKd68k=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -68,6 +73,8 @@ github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -75,6 +82,7 @@ github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc h1:9lDbC6Rz4bwmou+oE6Dt4Cb2BGMur5eR/GYptkKUVHo=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
@@ -96,3 +104,5 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/reuseport.go
+++ b/reuseport.go
@@ -3,40 +3,11 @@ package tcpreuse
 import (
 	"context"
 	"net"
-	"syscall"
 
 	reuseport "github.com/libp2p/go-reuseport"
 )
 
 var fallbackDialer net.Dialer
-
-// reuseErrShouldRetry diagnoses whether to retry after a reuse error.
-// if we failed to bind, we should retry. if bind worked and this is a
-// real dial error (remote end didnt answer) then we should not retry.
-func reuseErrShouldRetry(err error) bool {
-	if err == nil {
-		return false // hey, it worked! no need to retry.
-	}
-
-	// if it's a network timeout error, it's a legitimate failure.
-	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-		return false
-	}
-
-	errno, ok := err.(syscall.Errno)
-	if !ok { // not an errno? who knows what this is. retry.
-		return true
-	}
-
-	switch errno {
-	case syscall.EADDRINUSE, syscall.EADDRNOTAVAIL:
-		return true // failure to bind. retry.
-	case syscall.ECONNREFUSED:
-		return false // real dial error
-	default:
-		return true // optimistically default to retry.
-	}
-}
 
 // Dials using reuseport and then redials normally if that fails.
 func reuseDial(ctx context.Context, laddr *net.TCPAddr, network, raddr string) (con net.Conn, err error) {

--- a/reuseport_plan9.go
+++ b/reuseport_plan9.go
@@ -5,6 +5,11 @@ import (
 	"os"
 )
 
+const (
+	EADDRINUSE   = "address in use"
+	ECONNREFUSED = "connection refused"
+)
+
 // reuseErrShouldRetry diagnoses whether to retry after a reuse error.
 // if we failed to bind, we should retry. if bind worked and this is a
 // real dial error (remote end didnt answer) then we should not retry.
@@ -29,9 +34,9 @@ func reuseErrShouldRetry(err error) bool {
 	}
 
 	switch e1.Err.Error() {
-	case "address in use":
+	case EADDRINUSE:
 		return true
-	case "connection refused":
+	case ECONNREFUSED:
 		return false
 	default:
 		return true // optimistically default to retry.

--- a/reuseport_plan9.go
+++ b/reuseport_plan9.go
@@ -1,0 +1,39 @@
+package tcpreuse
+
+import (
+	"net"
+	"os"
+)
+
+// reuseErrShouldRetry diagnoses whether to retry after a reuse error.
+// if we failed to bind, we should retry. if bind worked and this is a
+// real dial error (remote end didnt answer) then we should not retry.
+func reuseErrShouldRetry(err error) bool {
+	if err == nil {
+		return false // hey, it worked! no need to retry.
+	}
+
+	// if it's a network timeout error, it's a legitimate failure.
+	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+		return false
+	}
+
+	e, ok := err.(*net.OpError)
+	if !ok {
+		return true
+	}
+
+	e1, ok := e.Err.(*os.PathError)
+	if !ok {
+		return true
+	}
+
+	switch e1.Err.Error() {
+	case "address in use":
+		return true
+	case "connection refused":
+		return false
+	default:
+		return true // optimistically default to retry.
+	}
+}

--- a/reuseport_posix.go
+++ b/reuseport_posix.go
@@ -1,0 +1,36 @@
+// +build !plan9
+
+package tcpreuse
+
+import (
+	"net"
+	"syscall"
+)
+
+// reuseErrShouldRetry diagnoses whether to retry after a reuse error.
+// if we failed to bind, we should retry. if bind worked and this is a
+// real dial error (remote end didnt answer) then we should not retry.
+func reuseErrShouldRetry(err error) bool {
+	if err == nil {
+		return false // hey, it worked! no need to retry.
+	}
+
+	// if it's a network timeout error, it's a legitimate failure.
+	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+		return false
+	}
+
+	errno, ok := err.(syscall.Errno)
+	if !ok { // not an errno? who knows what this is. retry.
+		return true
+	}
+
+	switch errno {
+	case syscall.EADDRINUSE, syscall.EADDRNOTAVAIL:
+		return true // failure to bind. retry.
+	case syscall.ECONNREFUSED:
+		return false // real dial error
+	default:
+		return true // optimistically default to retry.
+	}
+}

--- a/reuseport_test.go
+++ b/reuseport_test.go
@@ -1,3 +1,5 @@
+// +build !plan9
+
 package tcpreuse
 
 import (


### PR DESCRIPTION
Changes to `go.mod` has been left out: requires `go-netroute@v0.1.3` and
`go-reuseport@master` for Plan 9 support.